### PR TITLE
Keep search box visible till 1300px

### DIFF
--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -74,8 +74,8 @@ footer p {
     }
 }
 
-/* Hide the nav search bar on displays less than 1600px wide */
-@media (max-width: 1599px) {
+/* Hide the nav search bar on displays less than 1300px wide */
+@media (max-width: 1299px) {
     #navbar_search {
         display: none;
     }


### PR DESCRIPTION
Don't hide search box until width is less than 1300px

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1397

<!--
    Please include a summary of the proposed changes below.
-->
Currently the search box in the menu bar is hidden when the window is less than 1600px wide, this would change that to 1300px.